### PR TITLE
Fixed Perspective compilation

### DIFF
--- a/src/cpp/base.cpp
+++ b/src/cpp/base.cpp
@@ -410,9 +410,7 @@ t_cmp_charptr::operator()(const char* a, const char* b) const
     return std::strcmp(a, b) < 0;
 }
 
-bool
-t_cchar_umap_cmp::operator()(const char* x, const char* y) const
-{
+bool t_cchar_umap_cmp(const char *x, const char *y) {
     return strcmp(x, y) == 0;
 }
 

--- a/src/include/perspective/base.h
+++ b/src/include/perspective/base.h
@@ -442,11 +442,7 @@ struct PERSPECTIVE_EXPORT t_cmp_charptr
     bool operator()(const char* a, const char* b) const;
 };
 
-struct t_cchar_umap_cmp
-    : public std::binary_function<const char*, const char*, bool>
-{
-    bool operator()(const char* x, const char* y) const;
-};
+bool t_cchar_umap_cmp(const char *x, const char *y);
 
 struct t_cchar_umap_hash
 {

--- a/src/include/perspective/sym_table.h
+++ b/src/include/perspective/sym_table.h
@@ -11,6 +11,7 @@
 #include <perspective/first.h>
 #include <perspective/scalar.h>
 #include <unordered_map>
+#include <functional>
 
 namespace perspective
 {
@@ -18,8 +19,7 @@ namespace perspective
 class t_symtable
 {
     typedef std::unordered_map<const char*, const char*, t_cchar_umap_hash,
-        t_cchar_umap_cmp>
-        t_mapping;
+    std::function<bool(const char*, const char*)>> t_mapping;
 
 public:
     t_symtable();

--- a/src/include/perspective/vocab.h
+++ b/src/include/perspective/vocab.h
@@ -21,8 +21,7 @@ namespace perspective
 class PERSPECTIVE_EXPORT t_vocab
 {
     typedef std::unordered_map<const char*, t_uindex, t_cchar_umap_hash,
-        t_cchar_umap_cmp>
-        t_sidxmap;
+    std::function<bool(const char*, const char* )>> t_sidxmap;
 
 public:
     t_vocab();


### PR DESCRIPTION
There were some compilation issues because `std::binary_function` and friends were removed in C++17. This MR replaces those.